### PR TITLE
Ignore more files to keep npm smaller

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,9 @@
 .gitignore
+.npmignore
 .editorconfig
 
 node_modules/
 npm-debug.log
 
-*.test.js
+__tests__/
 .travis.yml


### PR DESCRIPTION
Best way to check your `.npmignore` run `npm pack` and then see what is in generated archive.