### PR TITLE
Fix comma rules for multiple selectors

### DIFF
--- a/__tests__/sass/multiple.sass
+++ b/__tests__/sass/multiple.sass
@@ -1,0 +1,6 @@
+.a, .b
+    color: red
+
+.a.b
+    color: red
+

--- a/__tests__/tests/__snapshots__/multiple.test.js.snap
+++ b/__tests__/tests/__snapshots__/multiple.test.js.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`multiple.sass 1`] = `
+Object {
+  "nodes": Array [
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 2,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "",
+        "between": "",
+      },
+      "selector": ".a, .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 5,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 5,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a.b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "type": "rule",
+    },
+  ],
+  "raws": Object {
+    "before": "",
+    "semicolon": undefined,
+  },
+  "source": Object {
+    "end": Object {
+      "column": 1,
+      "line": 6,
+    },
+    "input": Input {
+      "css": ".a, .b
+    color: red
+
+.a.b
+    color: red
+
+",
+      "id": "<input css 1>",
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/__tests__/tests/multiple.test.js
+++ b/__tests__/tests/multiple.test.js
@@ -1,0 +1,6 @@
+var getPostCssTreeFromSass =
+    require('../../helpers/getPostCssTreeFromSassTree');
+
+it('multiple.sass', function () {
+    expect(getPostCssTreeFromSass('multiple')).toMatchSnapshot();
+});

--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ function process(
         return root;
     } else if (node.type === 'ruleset') {
         // Loop to find the deepest ruleset node
-        var pseudoClassFirst = false;
         // Define new selector
         var selector = '';
         global.postcssSass.multiRuleProp = '';
@@ -105,6 +104,7 @@ function process(
                 }
             } else if (node.content[rContent].type === 'selector') {
                 // Creates selector for rule
+                if (rContent) selector += ', ';
                 for (
                     var sCurrentContent = 0;
                     sCurrentContent < node.content[rContent].length;
@@ -116,18 +116,6 @@ function process(
                     } else if (node.content[rContent]
                         .content[sCurrentContent].type === 'class') {
                         selector += '.';
-                    } else if (node.content[rContent]
-                        .content[sCurrentContent].type === 'typeSelector') {
-                        if (node.content[rContent]
-                            .content[sCurrentContent + 1] &&
-                            node.content[rContent]
-                                .content[sCurrentContent + 1]
-                                .type === 'pseudoClass' &&
-                            pseudoClassFirst) {
-                            selector += ', ';
-                        } else {
-                            pseudoClassFirst = true;
-                        }
                     } else if (node.content[rContent]
                         .content[sCurrentContent].type === 'pseudoClass') {
                         selector += ':';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-sass",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Sass parser for PostCSS, using gonzales-pe.",
   "keywords": [
     "postcss",


### PR DESCRIPTION
This PR intends to fix rules like this one:

```sass
.a, .b
  some-style
```

being reported as:

```json
{
  "selector": ".a.b"
}
```

Currently the code covers a similar scenario in a very specific way [here](https://github.com/AleshaOleg/postcss-sass/blob/master/index.js#L127). This PR replaces that specific implementation with a more generic one (by not taking into account node types).