### PR TITLE
Add delimiter handling

### DIFF
--- a/__tests__/__snapshots__/parse.test.js.snap
+++ b/__tests__/__snapshots__/parse.test.js.snap
@@ -1454,7 +1454,7 @@ exports[`parses list1.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 4,
@@ -1533,7 +1533,7 @@ exports[`parses list1.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 10,
@@ -1612,7 +1612,7 @@ exports[`parses list1.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 16,
@@ -1698,7 +1698,7 @@ exports[`parses list1.sass 1`] = `
                   }
                 }
               ],
-              \\"selector\\": \\".el-#{el2}\\",
+              \\"selector\\": \\".el-#{$el2}\\",
               \\"source\\": {
                 \\"start\\": {
                   \\"line\\": 23,
@@ -1804,7 +1804,7 @@ exports[`parses list1comment.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 4,
@@ -1883,7 +1883,7 @@ exports[`parses list1comment.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 10,
@@ -1962,7 +1962,7 @@ exports[`parses list1comment.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".el-#{el}\\",
+          \\"selector\\": \\".el-#{$el}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 16,
@@ -2058,7 +2058,7 @@ exports[`parses list1comment.sass 1`] = `
                   }
                 }
               ],
-              \\"selector\\": \\".el-#{el2}\\",
+              \\"selector\\": \\".el-#{$el2}\\",
               \\"source\\": {
                 \\"start\\": {
                   \\"line\\": 24,
@@ -2372,7 +2372,7 @@ exports[`parses map1.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".link-#{str}\\",
+          \\"selector\\": \\".link-#{$str}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 6,
@@ -2544,7 +2544,7 @@ exports[`parses map2.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".button-#{name}\\",
+          \\"selector\\": \\".button-#{$name}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 7,
@@ -2736,7 +2736,7 @@ exports[`parses map2comment.sass 1`] = `
               }
             }
           ],
-          \\"selector\\": \\".button-#{name}\\",
+          \\"selector\\": \\".button-#{$name}\\",
           \\"source\\": {
             \\"start\\": {
               \\"line\\": 9,
@@ -2766,6 +2766,421 @@ exports[`parses map2comment.sass 1`] = `
     },
     \\"input\\": {
       \\"file\\": \\"map2comment.sass\\"
+    }
+  }
+}"
+`;
+
+exports[`parses multiple.sass 1`] = `
+"{
+  \\"raws\\": {
+    \\"before\\": \\"\\"
+  },
+  \\"type\\": \\"root\\",
+  \\"nodes\\": [
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 2,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 2,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a, .b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 1,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 2,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 5,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 5,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a,.b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 4,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 5,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 8,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 8,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a .b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 7,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 8,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 11,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 11,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a + .b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 10,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 11,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 14,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 14,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a.b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 13,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 14,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 18,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 18,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a,\\\\n.b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 16,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 18,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\"\\"
+          },
+          \\"type\\": \\"rule\\",
+          \\"nodes\\": [
+            {
+              \\"raws\\": {
+                \\"before\\": \\"\\\\n        \\",
+                \\"between\\": \\": \\",
+                \\"semicolon\\": false
+              },
+              \\"type\\": \\"decl\\",
+              \\"prop\\": \\"color\\",
+              \\"value\\": \\"red\\",
+              \\"source\\": {
+                \\"start\\": {
+                  \\"line\\": 22,
+                  \\"column\\": 9
+                },
+                \\"end\\": {
+                  \\"line\\": 22,
+                  \\"column\\": 18
+                },
+                \\"input\\": {
+                  \\"file\\": \\"multiple.sass\\"
+                }
+              }
+            }
+          ],
+          \\"selector\\": \\".a, .b\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 21,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 22,
+              \\"column\\": 19
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".container\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 20,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 23,
+          \\"column\\": 1
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    },
+    {
+      \\"raws\\": {
+        \\"before\\": \\"\\\\n\\\\n\\",
+        \\"between\\": \\"\\"
+      },
+      \\"type\\": \\"rule\\",
+      \\"nodes\\": [
+        {
+          \\"raws\\": {
+            \\"before\\": \\"\\\\n    \\",
+            \\"between\\": \\": \\",
+            \\"semicolon\\": false
+          },
+          \\"type\\": \\"decl\\",
+          \\"prop\\": \\"color\\",
+          \\"value\\": \\"red\\",
+          \\"source\\": {
+            \\"start\\": {
+              \\"line\\": 25,
+              \\"column\\": 5
+            },
+            \\"end\\": {
+              \\"line\\": 25,
+              \\"column\\": 14
+            },
+            \\"input\\": {
+              \\"file\\": \\"multiple.sass\\"
+            }
+          }
+        }
+      ],
+      \\"selector\\": \\".a:not(.b) + .b\\",
+      \\"source\\": {
+        \\"start\\": {
+          \\"line\\": 24,
+          \\"column\\": 1
+        },
+        \\"end\\": {
+          \\"line\\": 25,
+          \\"column\\": 15
+        },
+        \\"input\\": {
+          \\"file\\": \\"multiple.sass\\"
+        }
+      }
+    }
+  ],
+  \\"source\\": {
+    \\"start\\": {
+      \\"line\\": 1,
+      \\"column\\": 1
+    },
+    \\"end\\": {
+      \\"line\\": 25,
+      \\"column\\": 15
+    },
+    \\"input\\": {
+      \\"file\\": \\"multiple.sass\\"
     }
   }
 }"

--- a/__tests__/sass/multiple.sass
+++ b/__tests__/sass/multiple.sass
@@ -1,0 +1,15 @@
+.a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+

--- a/__tests__/sass/multiple.sass
+++ b/__tests__/sass/multiple.sass
@@ -13,3 +13,6 @@
 .a.b
     color: red
 
+.a,
+.b
+    color: red

--- a/__tests__/sass/multiple.sass
+++ b/__tests__/sass/multiple.sass
@@ -16,3 +16,10 @@
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red

--- a/__tests__/tests/__snapshots__/multiple.test.js.snap
+++ b/__tests__/tests/__snapshots__/multiple.test.js.snap
@@ -1,0 +1,445 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`multiple.sass 1`] = `
+Object {
+  "nodes": Array [
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 2,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "",
+        "between": "",
+      },
+      "selector": ".a, .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 5,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 5,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a, .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 8,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 8,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 8,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 7,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 11,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 11,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a + .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 11,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 10,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 14,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 14,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a.b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 14,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 13,
+        },
+      },
+      "type": "rule",
+    },
+  ],
+  "raws": Object {
+    "before": "",
+    "semicolon": undefined,
+  },
+  "source": Object {
+    "end": Object {
+      "column": 1,
+      "line": 15,
+    },
+    "input": Input {
+      "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+",
+      "id": "<input css 1>",
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/__tests__/tests/__snapshots__/multiple.test.js.snap
+++ b/__tests__/tests/__snapshots__/multiple.test.js.snap
@@ -37,6 +37,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -77,6 +84,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
           "id": "<input css 1>",
@@ -122,6 +136,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -140,7 +161,7 @@ Object {
 ",
         "between": "",
       },
-      "selector": ".a, .b",
+      "selector": ".a,.b",
       "source": Object {
         "end": Object {
           "column": 15,
@@ -164,6 +185,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
           "id": "<input css 1>",
@@ -209,6 +237,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -251,6 +286,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
           "id": "<input css 1>",
@@ -296,6 +338,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -338,6 +387,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
           "id": "<input css 1>",
@@ -383,6 +439,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -425,6 +488,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
           "id": "<input css 1>",
@@ -470,6 +540,13 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -488,7 +565,8 @@ Object {
 ",
         "between": "",
       },
-      "selector": ".a, .b",
+      "selector": ".a,
+.b",
       "source": Object {
         "end": Object {
           "column": 15,
@@ -513,12 +591,271 @@ Object {
 .a,
 .b
     color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
 ",
           "id": "<input css 1>",
         },
         "start": Object {
           "column": 1,
           "line": 16,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "nodes": Array [
+            Object {
+              "prop": "color",
+              "raws": Object {
+                "before": "
+        ",
+                "between": ": ",
+                "semicolon": false,
+              },
+              "source": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 22,
+                },
+                "input": Input {
+                  "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
+",
+                  "id": "<input css 1>",
+                },
+                "start": Object {
+                  "column": 9,
+                  "line": 22,
+                },
+              },
+              "type": "decl",
+              "value": "red",
+            },
+          ],
+          "raws": Object {
+            "before": "
+    ",
+            "between": "",
+          },
+          "selector": ".a, .b",
+          "source": Object {
+            "end": Object {
+              "column": 19,
+              "line": 22,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 21,
+            },
+          },
+          "type": "rule",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".container",
+      "source": Object {
+        "end": Object {
+          "column": 1,
+          "line": 23,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 20,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 25,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 25,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a:not(.b) + .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 25,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
+    color: red
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 24,
         },
       },
       "type": "rule",
@@ -531,7 +868,7 @@ Object {
   "source": Object {
     "end": Object {
       "column": 15,
-      "line": 18,
+      "line": 25,
     },
     "input": Input {
       "css": ".a, .b
@@ -551,6 +888,13 @@ Object {
 
 .a,
 .b
+    color: red
+
+.container
+    .a, .b
+        color: red
+
+.a:not(.b) + .b
     color: red
 ",
       "id": "<input css 1>",

--- a/__tests__/tests/__snapshots__/multiple.test.js.snap
+++ b/__tests__/tests/__snapshots__/multiple.test.js.snap
@@ -34,6 +34,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -72,6 +75,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
           "id": "<input css 1>",
         },
@@ -113,6 +119,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -153,6 +162,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
           "id": "<input css 1>",
         },
@@ -194,6 +206,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -234,6 +249,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
           "id": "<input css 1>",
         },
@@ -275,6 +293,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -315,6 +336,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
           "id": "<input css 1>",
         },
@@ -356,6 +380,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
               "id": "<input css 1>",
             },
@@ -396,12 +423,102 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
           "id": "<input css 1>",
         },
         "start": Object {
           "column": 1,
           "line": 13,
+        },
+      },
+      "type": "rule",
+    },
+    Object {
+      "nodes": Array [
+        Object {
+          "prop": "color",
+          "raws": Object {
+            "before": "
+    ",
+            "between": ": ",
+            "semicolon": false,
+          },
+          "source": Object {
+            "end": Object {
+              "column": 14,
+              "line": 18,
+            },
+            "input": Input {
+              "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+",
+              "id": "<input css 1>",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 18,
+            },
+          },
+          "type": "decl",
+          "value": "red",
+        },
+      ],
+      "raws": Object {
+        "before": "
+
+",
+        "between": "",
+      },
+      "selector": ".a, .b",
+      "source": Object {
+        "end": Object {
+          "column": 15,
+          "line": 18,
+        },
+        "input": Input {
+          "css": ".a, .b
+    color: red
+
+.a,.b
+    color: red
+
+.a .b
+    color: red
+
+.a + .b
+    color: red
+
+.a.b
+    color: red
+
+.a,
+.b
+    color: red
+",
+          "id": "<input css 1>",
+        },
+        "start": Object {
+          "column": 1,
+          "line": 16,
         },
       },
       "type": "rule",
@@ -413,8 +530,8 @@ Object {
   },
   "source": Object {
     "end": Object {
-      "column": 1,
-      "line": 15,
+      "column": 15,
+      "line": 18,
     },
     "input": Input {
       "css": ".a, .b
@@ -432,6 +549,9 @@ Object {
 .a.b
     color: red
 
+.a,
+.b
+    color: red
 ",
       "id": "<input css 1>",
     },

--- a/__tests__/tests/multiple.test.js
+++ b/__tests__/tests/multiple.test.js
@@ -1,0 +1,6 @@
+var getPostCssTreeFromSass =
+    require('../../helpers/getPostCssTreeFromSassTree');
+
+it('multiple.sass', function () {
+    expect(getPostCssTreeFromSass('multiple')).toMatchSnapshot();
+});

--- a/parse.js
+++ b/parse.js
@@ -23,10 +23,38 @@ const DEFAULT_COMMENT_DECL = {
     right: ''
 };
 
+function extractNodeSource(lines, node) {
+    if (typeof node.content === 'string') {
+        return node.content;
+    }
+
+    const nodeLines = lines.slice(
+        node.start.line - 1,
+        node.end.line
+    );
+
+    // Adjust first and last columns
+    if (nodeLines.length === 1) {
+        // single line node
+        nodeLines[0] = nodeLines[0].substring(
+            node.start.column - 1,
+            node.end.column
+        );
+    } else {
+        // multi line node
+        nodeLines[0] = nodeLines[0].substring(node.start.column - 1);
+        nodeLines[nodeLines.length - 1] =
+            nodeLines[nodeLines.length - 1].substring(0, node.end.column);
+    }
+    return nodeLines.join('\n');
+}
+
 function process(node, parent, input, globalPostcssSass) {
     function bindedProcess(innerNode, innerParent = parent) {
         return process(innerNode, innerParent, input, globalPostcssSass);
     }
+
+    const lines = input.css.split('\n');
 
     switch (node.type) {
         case 'stylesheet': {
@@ -76,7 +104,7 @@ function process(node, parent, input, globalPostcssSass) {
 
                         if (rule.nodes.length !== 0) {
                             // Write selector to Rule, and remove last whitespace
-                            rule.selector = selector;
+                            rule.selector = selector.trim();
                             // Set parameters for Rule node
                             rule.parent = parent;
                             rule.source = {
@@ -89,49 +117,10 @@ function process(node, parent, input, globalPostcssSass) {
                         }
                         break;
                     }
+                    case 'delimiter':
+                    case 'space':
                     case 'selector': {
-                        // Creates selector for rule
-                        contentNode.content.forEach(innerContentNode => {
-                            switch (innerContentNode.type) {
-                                case 'id': {
-                                    selector += '#';
-                                    break;
-                                }
-                                case 'class': {
-                                    selector += '.';
-                                    if (innerContentNode.content.length > 1) {
-                                        innerContentNode.content.forEach((classContentNode) => {
-                                            if (classContentNode.content.constructor !== Array ) {
-                                                selector += classContentNode.content;
-                                            } else {
-                                                switch (classContentNode.type) {
-                                                    case 'interpolation': {
-                                                        classContentNode.content.forEach((interpolationContentNode) => {
-                                                            selector += `\#{${interpolationContentNode.content}}`;
-                                                        });
-                                                        break;
-                                                    }
-                                                    default:
-                                                }
-                                            }
-                                        });
-                                    }
-                                    break;
-                                }
-                                case 'pseudoClass': {
-                                    selector += ':';
-                                    break;
-                                }
-                                default:
-                            }
-                            if (innerContentNode.content.length === 1) {
-                                selector += innerContentNode.content;
-                            }
-                        });
-                        break;
-                    }
-                    case 'delimiter': {
-                        selector += ', ';
+                        selector += extractNodeSource(lines, contentNode);
                         break;
                     }
                     default:

--- a/parse.js
+++ b/parse.js
@@ -49,7 +49,6 @@ function process(node, parent, input, globalPostcssSass) {
         }
         case 'ruleset': {
             // Loop to find the deepest ruleset node
-            let pseudoClassFirst = false;
             // Define new selector
             let selector = '';
             globalPostcssSass.multiRuleProp = '';
@@ -92,7 +91,7 @@ function process(node, parent, input, globalPostcssSass) {
                     }
                     case 'selector': {
                         // Creates selector for rule
-                        contentNode.content.forEach((innerContentNode, i, nodes) => {
+                        contentNode.content.forEach(innerContentNode => {
                             switch (innerContentNode.type) {
                                 case 'id': {
                                     selector += '#';
@@ -119,14 +118,6 @@ function process(node, parent, input, globalPostcssSass) {
                                     }
                                     break;
                                 }
-                                case 'typeSelector': {
-                                    if (pseudoClassFirst && nodes[i + 1] && nodes[i + 1].type === 'pseudoClass') {
-                                        selector += ', ';
-                                    } else {
-                                        pseudoClassFirst = true;
-                                    }
-                                    break;
-                                }
                                 case 'pseudoClass': {
                                     selector += ':';
                                     break;
@@ -137,6 +128,10 @@ function process(node, parent, input, globalPostcssSass) {
                                 selector += innerContentNode.content;
                             }
                         });
+                        break;
+                    }
+                    case 'delimiter': {
+                        selector += ', ';
                         break;
                     }
                     default:


### PR DESCRIPTION
This PR intends to fix rules like this one:

```sass
.a, .b
  some-style
```

being reported as:

```json
{
  "selector": ".a.b"
}
```

Related to #25 (but on `development` branch)