### PR TITLE
Support for decl.raws.important

### DIFF
--- a/__tests__/tests/__snapshots__/important.test.js.snap
+++ b/__tests__/tests/__snapshots__/important.test.js.snap
@@ -12,6 +12,7 @@ Object {
             "before": "
     ",
             "between": ": ",
+            "important": " !important",
             "semicolon": false,
           },
           "source": Object {
@@ -34,7 +35,7 @@ Object {
             },
           },
           "type": "decl",
-          "value": "red ",
+          "value": "red",
         },
         Object {
           "nodes": Array [
@@ -45,6 +46,7 @@ Object {
                 "before": "
         ",
                 "between": ": ",
+                "important": " !important",
                 "semicolon": false,
               },
               "source": Object {
@@ -67,7 +69,7 @@ Object {
                 },
               },
               "type": "decl",
-              "value": "none ",
+              "value": "none",
             },
             Object {
               "prop": "color",

--- a/parse.js
+++ b/parse.js
@@ -186,11 +186,11 @@ function process(node, parent, input, globalPostcssSass) {
             declarationNode.prop = '';
 
             // Object to store raws for Declaration
-            const declarationRaws = {
+            const declarationRaws = Object.assign(declarationNode.raws, {
                 before: globalPostcssSass.before || DEFAULT_RAWS_DECL.before,
                 between: DEFAULT_RAWS_DECL.between,
                 semicolon: DEFAULT_RAWS_DECL.semicolon
-            };
+            });
 
             globalPostcssSass.property = false;
             globalPostcssSass.betweenBefore = false;
@@ -276,7 +276,6 @@ function process(node, parent, input, globalPostcssSass) {
                     input: input
                 };
                 declarationNode.parent = parent;
-                declarationNode.raws = declarationRaws;
                 parent.nodes.push(declarationNode);
             }
 
@@ -302,7 +301,13 @@ function process(node, parent, input, globalPostcssSass) {
                 node.content.forEach(contentNode => {
                     switch (contentNode.type) {
                         case 'important': {
+                            parent.raws.important = contentNode.content;
                             parent.important = true;
+                            const match = parent.value.match(/^(.*?)(\s*)$/);
+                            if (match) {
+                                parent.raws.important = match[2] + parent.raws.important;
+                                parent.value = match[1];
+                            }
                             break;
                         }
                         case 'parentheses': {

--- a/stringifier.js
+++ b/stringifier.js
@@ -26,10 +26,10 @@ SassStringifier.prototype.block = function (node, start) {
 };
 
 SassStringifier.prototype.decl = function (node) {
-    const between = node.raws.between || DEFAULT_RAW.colon;
-    const string  = node.prop + between + this.rawValue(node, 'value');
+    const between = this.raw(node, 'between', 'colon');
+    let string = node.prop + between + this.rawValue(node, 'value');
     if (node.important) {
-        string += '!important';
+        string += node.raws.important || ' !important';
     }
     this.builder(string, node);
 };


### PR DESCRIPTION
- move spaces from suffix of `decl.value` to prefix of  `decl.raws.important`
- fix `TypeError: Assignment to constant variable.`