### PR TITLE
Add failing star selector to tests.

### DIFF
--- a/__tests__/cases/selectors.sass
+++ b/__tests__/cases/selectors.sass
@@ -10,3 +10,6 @@
 .a,
 .b
   color: red
+
+*
+  color: red


### PR DESCRIPTION
Hi @AleshaOleg, I was trying to use stylelint and found this problem with the `*` selector. I might attempt to fix it later but I might not get to it.