### PR TITLE
Ignore unsupported at-keywords

### DIFF
--- a/__tests__/__snapshots__/parse.test.js.snap
+++ b/__tests__/__snapshots__/parse.test.js.snap
@@ -1617,6 +1617,29 @@ exports[`parses global.sass 1`] = `
 }"
 `;
 
+exports[`parses import.sass 1`] = `
+"{
+  \\"raws\\": {
+    \\"before\\": \\"\\"
+  },
+  \\"type\\": \\"root\\",
+  \\"nodes\\": [],
+  \\"source\\": {
+    \\"start\\": {
+      \\"line\\": 1,
+      \\"column\\": 1
+    },
+    \\"end\\": {
+      \\"line\\": 1,
+      \\"column\\": 27
+    },
+    \\"input\\": {
+      \\"file\\": \\"import.sass\\"
+    }
+  }
+}"
+`;
+
 exports[`parses important.sass 1`] = `
 "{
   \\"raws\\": {

--- a/__tests__/cases/import.sass
+++ b/__tests__/cases/import.sass
@@ -1,0 +1,1 @@
+@import './variables.sass'

--- a/__tests__/stringify.test.js
+++ b/__tests__/stringify.test.js
@@ -6,9 +6,14 @@ const stringify = require('../stringify')
 const parse = require('../parse')
 const read = require('./utils/read')
 
+const ignoredFiles = [
+  'import.sass'
+]
+
 const tests = fs
   .readdirSync(path.join(__dirname, 'cases'))
   .filter(i => path.extname(i) === '.sass')
+  .filter(i => !ignoredFiles.includes(i))
 
 for (let name of tests) {
   it('stringifies ' + name, () => {

--- a/parser.es6
+++ b/parser.es6
@@ -20,6 +20,10 @@ const DEFAULT_COMMENT_DECL = {
   before: ''
 }
 
+const SUPPORTED_AT_KEYWORDS = [
+  'media'
+]
+
 class SassParser {
   constructor (input) {
     this.input = input
@@ -426,6 +430,10 @@ class SassParser {
   }
 
   atrule (node, parent) {
+    // Skip unsupported @xxx rules
+    let supportedNode = node.content[0].content.some(contentNode => SUPPORTED_AT_KEYWORDS.includes(contentNode.content))
+    if (!supportedNode) return
+
     let atrule = postcss.rule()
     atrule.selector = ''
     atrule.raws = {


### PR DESCRIPTION
Fixed: https://github.com/AleshaOleg/postcss-sass/issues/120

`stylelint` raises error on inspecting `@import` syntax because of the supported `@xxx` is only `@media`.
Exclude `@import`, `@charset` and as so on from atrule until other at-keywords are supported.